### PR TITLE
Fix JVM arguments usage with redeploy

### DIFF
--- a/src/main/kotlin/io/vertx/gradle/VertxPlugin.kt
+++ b/src/main/kotlin/io/vertx/gradle/VertxPlugin.kt
@@ -162,6 +162,9 @@ class VertxPlugin : Plugin<Project> {
 
       if (vertxExtension.redeploy) {
         args("--launcher-class", vertxExtension.launcher)
+        if (vertxExtension.jvmArgs.isNotEmpty()) {
+          args("--java-opts", vertxExtension.jvmArgs.joinToString(separator = " ", prefix = "\"", postfix = "\""))
+        }
         args("--redeploy", vertxExtension.watch.joinToString(separator = ","))
         if (vertxExtension.onRedeploy.isNotEmpty()) {
           args("--on-redeploy", "$gradleCommand ${vertxExtension.onRedeploy.joinToString(separator = " ")}")


### PR DESCRIPTION
This will fix #8 

After applying this changes - finally I've got output as expected:

```
17:57:25: Executing task 'vertxRun'...

:compileJava
:processResources
:classes
:vertxRun
 INFO 2017-12-04 17:57:27.671 -- [                 main]                  i.v.c.i.l.c.Watcher: Watched paths: [/home/spodin/temp/jvmargs/src]
 INFO 2017-12-04 17:57:27.675 -- [                 main]                  i.v.c.i.l.c.Watcher: Starting the vert.x application in redeploy mode
Starting vert.x application...
21bcb3a3-b3d2-4be2-b0da-7ec16c9443d4-redeploy
 INFO 2017-12-04 17:57:29.225 -- [.x-eventloop-thread-1]    i.v.c.i.l.c.VertxIsolatedDeployer: Succeeded in deploying verticle
 INFO 2017-12-04 17:57:29.236 -- [.x-eventloop-thread-0]                   s.e.j.MainVerticle: HTTP server started on 8080
 INFO 2017-12-04 17:57:29.237 -- [.x-eventloop-thread-0]                   s.e.j.MainVerticle: vertx.logger-delegate-factory-class-name = io.vertx.core.logging.Log4j2LogDelegateFactory
```

Signed-off-by: Vasiliy Spodin <v@spodin.engineer>