### PR TITLE
Upgrade Vert.x to v3.5.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ dependencies {
 
 vertx {
   mainVerticle = "sample.App"
-  vertxVersion = "3.5.0" // <3>
+  vertxVersion = "3.5.1" // <3>
 }
 ----
 <1> Part of the Vert.x stack, so the version can be omitted.
@@ -126,7 +126,7 @@ The following configuration can be applied, and matches the `vertx run` command-
 
 |`vertxVersion`
 |the Vert.x version to use
-|`"3.5.0"`
+|`"3.5.1"`
 
 |`launcher`
 |the main class name

--- a/src/main/kotlin/io/vertx/gradle/VertxExtension.kt
+++ b/src/main/kotlin/io/vertx/gradle/VertxExtension.kt
@@ -25,7 +25,7 @@ import org.gradle.api.Project
  */
 open class VertxExtension(private val project: Project) {
 
-  var vertxVersion = "3.5.0"
+  var vertxVersion = "3.5.1"
 
   var launcher = "io.vertx.core.Launcher"
   var mainVerticle = ""


### PR DESCRIPTION
This will upgrade Vert.x version to the latest [3.5.1 release](https://github.com/vert-x3/wiki/wiki/3.5.1-Release-Notes) in extension class and README.