### PR TITLE
Custom Launcher with main verticle configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -133,7 +133,7 @@ The following configuration can be applied, and matches the `vertx run` command-
 | `io.vertx.core.Launcher`
 
 |`mainVerticle`
-|the main verticle, when using `io.vertx.core.Launcher` as `launcher`
+|the main verticle
 | `""`
 
 |`args`

--- a/src/main/kotlin/io/vertx/gradle/VertxPlugin.kt
+++ b/src/main/kotlin/io/vertx/gradle/VertxPlugin.kt
@@ -151,13 +151,13 @@ class VertxPlugin : Plugin<Project> {
 
       main = if (vertxExtension.redeploy) "io.vertx.core.Launcher" else vertxExtension.launcher
 
-      if (vertxExtension.launcher == "io.vertx.core.Launcher") {
-        if (vertxExtension.mainVerticle.isBlank()) {
+      if (vertxExtension.mainVerticle.isBlank()) {
+        if (vertxExtension.launcher == "io.vertx.core.Launcher") {
           throw GradleException("Extension property vertx.mainVerticle must be specified when using io.vertx.core.Launcher as a launcher")
         }
-        args("run", vertxExtension.mainVerticle)
-      } else if (vertxExtension.redeploy) {
         args("run")
+      } else {
+        args("run", vertxExtension.mainVerticle)
       }
 
       if (vertxExtension.redeploy) {
@@ -226,4 +226,3 @@ class VertxPlugin : Plugin<Project> {
     return arrayListOf(debugger, disableEventLoopchecker, disableWorkerchecker, mark)
   }
 }
-


### PR DESCRIPTION
This PR is to make possible to use a custom Launcher with a main verticle configuration. 
It's the same case reported on issue https://github.com/jponge/vertx-gradle-plugin/issues/5