### PR TITLE
Docker support based on Jib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ plugins {
 
 repositories {
   jcenter()
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
   mavenLocal()
 }
 
@@ -35,6 +40,7 @@ dependencies {
   implementation ('com.netflix.nebula:nebula-dependency-recommender:5.2.0') {
     exclude group: 'org.jetbrains.kotlin'
   }
+  implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:0.9.7'
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'com.mashape.unirest:unirest-java:1.4.9'

--- a/src/main/kotlin/io/vertx/gradle/VertxPlugin.kt
+++ b/src/main/kotlin/io/vertx/gradle/VertxPlugin.kt
@@ -18,6 +18,8 @@ package io.vertx.gradle
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.google.cloud.tools.jib.gradle.JibExtension
+import com.google.cloud.tools.jib.gradle.JibPlugin
 import netflix.nebula.dependency.recommender.DependencyRecommendationsPlugin
 import netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer
 import org.apache.tools.ant.taskdefs.condition.Os
@@ -57,6 +59,7 @@ class VertxPlugin : Plugin<Project> {
       addVertxCoreDependency(project)
       defineMainClassName(project)
       configureShadowPlugin(project)
+      configureJibPlugin(project)
       configureVertxRunTask(project)
       configureVertxDebugTask(project)
     }
@@ -91,6 +94,7 @@ class VertxPlugin : Plugin<Project> {
     project.pluginManager.apply(ApplicationPlugin::class.java)
     project.pluginManager.apply(ShadowPlugin::class.java)
     project.pluginManager.apply(DependencyRecommendationsPlugin::class.java)
+    project.pluginManager.apply(JibPlugin::class.java)
     logger.debug("The plugins needed by the Vert.x plugin have been applied")
   }
 
@@ -139,6 +143,27 @@ class VertxPlugin : Plugin<Project> {
       }
     }
     logger.debug("The shadow plugin has been configured")
+  }
+
+  private fun configureJibPlugin(project: Project) {
+    val jibExtension = project.extensions.getByName("jib") as JibExtension
+    val vertxExtension = project.vertxExtension()
+    val tag = if (project.version != Project.DEFAULT_VERSION) project.version else "latest"
+    jibExtension.apply {
+      from { imageConfiguration ->
+        imageConfiguration.image = "openjdk:8-jdk-alpine"
+      }
+      to { imageConfiguration ->
+        imageConfiguration.image = "${project.name}:$tag"
+      }
+      container { containerParameters ->
+        containerParameters.useCurrentTimestamp = true
+        containerParameters.jvmFlags = vertxExtension.jvmArgs
+        containerParameters.mainClass = vertxExtension.launcher
+        containerParameters.args = vertxExtension.args
+      }
+    }
+    logger.debug("The jib plugin has been configured")
   }
 
   private fun createVertxTasks(project: Project) {


### PR DESCRIPTION
A proposal for #18 

It simply works (i used the `openjdk:8-jdk-alpine` as default image). 
My concerns with jib:
- According to their [FAQ](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#can-i-build-to-a-local-docker-daemon) the local build requires a weird `docker pull` to make the image available. We'll see the result on a CI environment. Plus, it requires to run the `jibDockerBuild` rather than the simple `jib` task.

- The docker build is 100% programatically, we can't override with a classic `Dockerfile` (discussed [here](https://github.com/GoogleContainerTools/jib/issues/657). I understand the discussion but it's not ops-friendly

I wait for your feedback before starting the documentation.