### PR TITLE
Added vertx extension to make the plugin more Kotlin DSL friendly

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,6 +112,24 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {   // <3>
 <2> This verticle can be written in Kotlin (or Java).
 <3> By default Kotlin compiles to Java 6 bytecode, so it is worth changing all compilation tasks to match Java 8 bytecode.
 
+=== Using Kotlin DSL
+
+[source,kotlin]
+----
+plugins {
+  id("io.vertx.vertx-plugin") version "x.y.z"
+}
+
+repositories {
+  jcenter()
+}
+
+vertx { // <1>
+  mainVerticle = "sample.App"
+}
+----
+<1> Extension method on `org.gradle.api.Project`.
+
 == Configuration
 
 The configuration happens through the `vertx` Gradle extension.

--- a/src/main/kotlin/io/vertx/gradle/VertxExtension.kt
+++ b/src/main/kotlin/io/vertx/gradle/VertxExtension.kt
@@ -49,3 +49,9 @@ open class VertxExtension(private val project: Project) {
     return "VertxExtension(project=$project, vertxVersion='$vertxVersion', launcher='$launcher', mainVerticle='$mainVerticle', args=$args, config='$config', workDirectory='$workDirectory', jvmArgs=$jvmArgs, redeploy=$redeploy, watch=$watch, onRedeploy='$onRedeploy', redeployScanPeriod=$redeployScanPeriod, redeployGracePeriod=$redeployGracePeriod, redeployTerminationPeriod=$redeployTerminationPeriod, debugPort=$debugPort, debugSuspend=$debugSuspend)"
   }
 }
+
+/**
+ * Extension method to make easier the configuration of the plugin when used with the Gradle Kotlin DSL
+ */
+fun Project.vertx(configure: VertxExtension.() -> Unit) =
+  extensions.configure(VertxExtension::class.java, configure)


### PR DESCRIPTION
The extension is based on what other Kotlin DSL projects do, like [detekt](https://github.com/arturbosch/detekt/blob/master/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt). 

Do you have any plan on using the Kotlin DSL for all Gradle files instead of the Groovy one? Because I can help with that if you want.