### PR TITLE
Upgrade default version of Vert.x to 3.9.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,7 +78,7 @@ dependencies {
 
 vertx {
   mainVerticle = "sample.App"
-  vertxVersion = "3.9.0" // <3>
+  vertxVersion = "3.9.1" // <3>
 }
 ----
 <1> Part of the Vert.x stack, so the version can be omitted.
@@ -152,7 +152,7 @@ The following configuration can be applied, and matches the `vertx run` command-
 
 |`vertxVersion`
 |the Vert.x version to use
-|`"3.9.0"`
+|`"3.9.1"`
 
 |`launcher`
 |the main class name

--- a/src/main/kotlin/io/vertx/gradle/VertxExtension.kt
+++ b/src/main/kotlin/io/vertx/gradle/VertxExtension.kt
@@ -25,7 +25,7 @@ import org.gradle.api.Project
  */
 open class VertxExtension(private val project: Project) {
 
-  var vertxVersion = "3.9.0"
+  var vertxVersion = "3.9.1"
 
   var launcher = "io.vertx.core.Launcher"
   var mainVerticle = ""


### PR DESCRIPTION
Default to Vert.x 3.9.1 instead of 3.9.0.