### PR TITLE
Upgrade default version of Vert.x to 3.9.3

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -80,7 +80,7 @@ dependencies {
 
 vertx {
   mainVerticle = "sample.App"
-  vertxVersion = "3.9.2" // <3>
+  vertxVersion = "3.9.3" // <3>
 }
 ----
 <1> Part of the Vert.x stack, so the version can be omitted.
@@ -154,7 +154,7 @@ The following configuration can be applied, and matches the `vertx run` command-
 
 |`vertxVersion`
 |the Vert.x version to use
-|`"3.9.2"`
+|`"3.9.3"`
 
 |`launcher`
 |the main class name

--- a/src/main/kotlin/io/vertx/gradle/VertxExtension.kt
+++ b/src/main/kotlin/io/vertx/gradle/VertxExtension.kt
@@ -25,7 +25,7 @@ import org.gradle.api.Project
  */
 open class VertxExtension(private val project: Project) {
 
-  var vertxVersion = "3.9.2"
+  var vertxVersion = "3.9.3"
 
   var launcher = "io.vertx.core.Launcher"
   var mainVerticle = ""


### PR DESCRIPTION
Change default version of Vert.x to 3.9.3, not 3.9.2.